### PR TITLE
Improve i18n routes

### DIFF
--- a/modules/i18n-routes/index.js
+++ b/modules/i18n-routes/index.js
@@ -21,13 +21,6 @@ module.exports = function (moduleOptions) {
     options: moduleOptions
   })
 
-  // Add redirect page
-  this.addTemplate({
-    src: resolve(__dirname, './templates/redirect.vue'),
-    fileName: 'i18n-routes.redirect.vue',
-    options: moduleOptions
-  })
-
   // Add routes
   this.extendRoutes(function (routes) {
     routes.sort((a, b) => {
@@ -35,11 +28,7 @@ module.exports = function (moduleOptions) {
     })
     routes.forEach(route => {
       const {path} = route
-      route.path = `/:lang(\\w{2})${path}`
-    })
-    routes.push({
-      path: '/',
-      component: '.nuxt/i18n-routes.redirect.vue'
+      route.path = `/:lang(\\w{2})?${path}`
     })
     return routes
   })

--- a/modules/i18n-routes/templates/plugin.js
+++ b/modules/i18n-routes/templates/plugin.js
@@ -32,31 +32,34 @@ export default ({app, store}) => {
     silentTranslationWarn: true
   })
 
-
-  let mixinMethods = {
-    localePath: function (url) {
-      return '/' + store.state['i18n-routes'].language + url
-    },
-    detectLanguage: function () {
-      let languageList = []
-      if (typeof navigator !== 'undefined') {
-        if (navigator.userLanguage) {
-          languageList.unshift(navigator.userLanguage.substring(0, 2))
-        }
-        if (navigator.language) {
-          languageList.unshift(navigator.language.substring(0, 2))
-        }
-      }
-      let language = languageList.find((language) => {
-        return (options.languages.indexOf(language) !== -1)
-      })
-      return language || options.languages[0]
-    }
-  }
   Vue.use({
     install (app) {
       app.mixin({
-        methods: mixinMethods
+        methods: {
+          localePath (url) {
+            return '/' + store.state['i18n-routes'].language + url
+          },
+          detectLanguage () {
+            let languageList = []
+            if (typeof navigator !== 'undefined') {
+              if (navigator.userLanguage) {
+                languageList.unshift(navigator.userLanguage.substring(0, 2))
+              }
+              if (navigator.language) {
+                languageList.unshift(navigator.language.substring(0, 2))
+              }
+            }
+            let language = languageList.find((language) => {
+              return (options.languages.indexOf(language) !== -1)
+            })
+            return language || options.languages[0]
+          }
+        },
+        beforeMount () {
+          if (!this.$route.params.lang) {
+            this.$router.replace({params: {lang: this.detectLanguage()}})
+          }
+        }
       })
     }
   })

--- a/modules/i18n-routes/templates/plugin.js
+++ b/modules/i18n-routes/templates/plugin.js
@@ -59,6 +59,24 @@ export default ({app, store}) => {
           if (!this.$route.params.lang) {
             this.$router.replace({params: {lang: this.detectLanguage()}})
           }
+        },
+        head () {
+          if (!this.$route) {
+            return
+          }
+          let languageParamList = options.languages.concat(null)
+          let alternateLinks = languageParamList.map((languageParam) => {
+            let hreflang = (languageParam ? languageParam : 'x-default')
+            return {
+              hid: 'alternate-lang-' + hreflang,
+              rel: 'alternate',
+              hreflang: hreflang,
+              href: this.$router.resolve({params: {lang: languageParam}}).href
+            }
+          })
+          return {
+            link: alternateLinks
+          }
         }
       })
     }

--- a/modules/i18n-routes/templates/redirect.vue
+++ b/modules/i18n-routes/templates/redirect.vue
@@ -1,9 +1,0 @@
-<template></template>
-
-<script>
-  export default {
-    beforeMount () {
-      this.$router.replace({name: 'index', params: {lang: this.detectLanguage()}})
-    }
-  }
-</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -17,6 +17,11 @@ module.exports = {
     link: [
       {
         rel: 'alternate',
+        hreflang: 'x-default',
+        href: 'https://www.madeinbasel.org/'
+      },
+      {
+        rel: 'alternate',
         hreflang: 'en',
         href: 'https://www.madeinbasel.org/en'
       },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,7 +5,8 @@ module.exports = {
     title: 'MADE IN BASEL',
     titleTemplate: '%s - MADE IN BASEL',
 
-    meta: [{
+    meta: [
+      {
         charset: 'utf-8'
       },
       {
@@ -13,7 +14,8 @@ module.exports = {
         content: 'width=device-width, initial-scale=1'
       }
     ],
-    link: [{
+    link: [
+      {
         rel: 'alternate',
         hreflang: 'en',
         href: 'https://www.madeinbasel.org/en'
@@ -54,7 +56,8 @@ module.exports = {
     color: '#191919'
   },
 
-  css: [{
+  css: [
+    {
       src: '~assets/styles/app.styl',
       lang: 'styl'
     },
@@ -64,7 +67,8 @@ module.exports = {
     }
   ],
 
-  plugins: [{
+  plugins: [
+    {
       src: '~plugins/vuetify.js'
     },
     {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -111,9 +111,5 @@ module.exports = {
         })
       }
     }
-  },
-
-  generate: {
-    routes: ['/en', '/de', '/en/admin', '/de/admin', '/en/stories', '/de/stories', '/en/apply', '/de/apply', '/en/label', '/de/label', '/en/explore', '/de/explore', '/en/about', '/de/about']
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -16,21 +16,6 @@ module.exports = {
     ],
     link: [
       {
-        rel: 'alternate',
-        hreflang: 'x-default',
-        href: 'https://www.madeinbasel.org/'
-      },
-      {
-        rel: 'alternate',
-        hreflang: 'en',
-        href: 'https://www.madeinbasel.org/en'
-      },
-      {
-        rel: 'alternate',
-        hreflang: 'de',
-        href: 'https://www.madeinbasel.org/de'
-      },
-      {
         rel: 'icon',
         type: 'image/x-icon',
         href: '/favicon.ico'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "vue-i18n": "^7.3.2",
     "vue-scroll-reveal": "^1.0.3",
     "vuetify": "^0.16.9",
-    "webfontloader": "^1.6.28"
+    "webfontloader": "^1.6.28",
+    "path-to-regexp": "^2.1.0"
   },
   "scripts": {
     "dev": "nuxt",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3964,6 +3964,10 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.1.0.tgz#7e30f9f5b134bd6a28ffc2e3ef1e47075ac5259b"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"


### PR DESCRIPTION
Two changes:
- The routes to *generate* are automatically determined, no need anymore to define them in the config.
- The `lang` parameter is optional for each route. When loaded without a language, the page will determine the language on the client-side and redirect to the the localized version.
- Generate "alternate" head links. They are relative by default, unless we set [`router.base`](https://nuxtjs.org/api/configuration-router/) - but not sure if that's a good idea.